### PR TITLE
skip key renaming in _load_from_state_dict

### DIFF
--- a/open_vocab_seg/modeling/heads/open_vocab_mask_former_head.py
+++ b/open_vocab_seg/modeling/heads/open_vocab_mask_former_head.py
@@ -41,8 +41,8 @@ class OpenVocabMaskFormerHead(nn.Module):
             logger = logging.getLogger(__name__)
             for k in list(state_dict.keys()):
                 newk = k
-                if "sem_seg_head" in k and not k.startswith(prefix + "predictor"):
-                    newk = k.replace(prefix, prefix + "pixel_decoder.")
+                # if "sem_seg_head" in k and not k.startswith(prefix + "predictor"):
+                #    newk = k.replace(prefix, prefix + "pixel_decoder.")
                     # logger.debug(f"{k} ==> {newk}")
                 if newk != k:
                     state_dict[newk] = state_dict[k]


### PR DESCRIPTION
The keys containing "sem_seg_head.pixel_decoder" are changed to "sem_seg_head.pixel_decoder.pixel_decoder" which is not found in the provided model weights.